### PR TITLE
delete duplicate key in v1 openapi definition

### DIFF
--- a/api-reference/v1-openapi.json
+++ b/api-reference/v1-openapi.json
@@ -90,11 +90,6 @@
                     "description": "Timeout in milliseconds for the request",
                     "default": 30000
                   },
-                  "removeBase64Images": {
-                    "type": "boolean",
-                    "description": "Remove base64 encoded images from the output",
-                    "default": true
-                  },
                   "extract": {
                     "type": "object",
                     "description": "Extract object",


### PR DESCRIPTION
this was causing your v2 openapi spec to be invalid.